### PR TITLE
Handle properly a case where VIRTUAL_ENV is unset

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -3,7 +3,7 @@ function precmd() {
 }
 
 function maybeworkon() {
-  if [ "$1" != "$(basename $VIRTUAL_ENV)" ]; then
+  if [[ -z "$VIRTUAL_ENV" || "$1" != "$(basename $VIRTUAL_ENV)" ]]; then
      if [ -z "$AUTOSWITCH_SILENT" ]; then
         printf "Switching virtualenv: %s  " $1
      fi


### PR DESCRIPTION
When a virtualenv is activated, the following error might occur if we don't use default virtualenv.

```
basename: missing operand
Try 'basename --help' for more information.
Switching virtualenv: xxxxx  [Python 2.7.12]
```

This patch is a fix to this, by adding a condition to check whether VIRTUAL_ENV is set.