### PR TITLE
Auto switch if .venv is in parent directories

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -29,7 +29,7 @@ function check_venv_path()
         if [ "$check_dir" = "/" ]; then
             return
         fi
-        check_venv_path $(dirname "$check_dir")
+        check_venv_path "$(dirname "$check_dir")"
     fi
 }
 


### PR DESCRIPTION
Currently, if there is a .venv file in the root of a project directory, and you switch to a child directory, it will not activate the virtualenv. This pull request adds a function that recursively searches parent directories looking for a .venv file. 