### PR TITLE
Fixed mkvenv to set AUTOSWITCH_PROJECT

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -102,5 +102,6 @@ function mkvenv()
     done
     echo "$venv_name" > ".venv"
     chmod 600 .venv
+    AUTOSWITCH_PROJECT="$PWD"
   fi
 }


### PR DESCRIPTION
When `mkvenv` is run, the new virtualenv is activated, but `AUTOSWITCH_PROJECT` is not set, so changing out of the project tree does not deactivate the virtualenv. 