### PR TITLE
Fix stat command usage to support macOS/FreeBSD

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -38,10 +38,18 @@ function _check_venv()
 
         SWITCH_TO=""
 
+        # Get the .venv file, scanning parent directories
         venv_path=$(_check_venv_path "$PWD")
         if [[ -n "$venv_path" ]]; then
-          file_owner="$(stat -c %u "$venv_path")"
-          file_permissions="$(stat -c %a "$venv_path")"
+
+          stat --version &> /dev/null
+          if [[ $? -eq 0 ]]; then   # Linux, or GNU stat
+            file_owner="$(stat -c %u "$venv_path")"
+            file_permissions="$(stat -c %a "$venv_path")"
+          else                      # macOS, or FreeBSD stat
+            file_owner="$(stat -f %u "$venv_path")"
+            file_permissions="$(stat -f %OLp "$venv_path")"
+          fi
 
           if [[ "$file_owner" != "$(id -u)" ]]; then
             echo "AUTOSWITCH WARNING: Virtualenv will not be activated"


### PR DESCRIPTION
In macOS or FreeBSD systems with the stat command different from GNU coreutils, `stat` does not support the `-c` flag.

```
stat: illegal option -- c
usage: stat [-FlLnqrsx] [-f format] [-t timefmt] [file ...]
stat: illegal option -- c
usage: stat [-FlLnqrsx] [-f format] [-t timefmt] [file ...]
AUTOSWITCH WARNING: Virtualenv will not be activated

Reason: Found a .venv file but it is not owned by the current user
Change ownership of .venv to 'USERNAME' to fix this
```

To support those systems, we can use different flag and format strings by detecting which variant of `stat` we are using.