### PR TITLE
Detect and activate virtualenv on sourcing the plugin

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -131,3 +131,6 @@ function mkvenv()
 autoload -Uz add-zsh-hook
 add-zsh-hook -D chpwd check_venv
 add-zsh-hook chpwd check_venv
+
+# auto-detect virtualenv on zsh startup
+[[ -o interactive ]] && check_venv


### PR DESCRIPTION
Previously, virtualenv was not being activated on zsh startup (e.g.
opening a new tmux pane with initial working directory with .venv).

Now the virtualenv will be automatically activated on zsh startup.