### PR TITLE
If there is pipenv virtualenv, activate it.

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -45,12 +45,12 @@ function _maybeworkon() {
 
 
 function _maybepipenv() {
-  if [[ -z $VIRTUAL_ENV ]]; then
+  if [[ -z "$VIRTUAL_ENV" || "$1" != "$VIRTUAL_ENV" ]]; then
      if [ -z "$AUTOSWITCH_SILENT" ]; then
-        printf "Switching pipenv: %s  " $(basename $(pipenv --venv))
+        printf "Switching pipenv: %s  " "$(basename "$1")"
      fi
 
-     . $(pipenv --venv)/bin/activate
+     . "$1"/bin/activate
 
      if [ -z "$AUTOSWITCH_SILENT" ]; then
         _print_python_version
@@ -116,7 +116,7 @@ function check_venv()
         if [[ -n "$SWITCH_TO" ]]; then
           _maybeworkon "$SWITCH_TO"
         elif [[ -n `pipenv --venv 2>/dev/null` ]]; then
-          _maybepipenv
+          _maybepipenv "$(pipenv --venv)"
         else
           _default_venv
         fi

--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -16,6 +16,19 @@ if ! type workon > /dev/null; then
     printf "\n"
 fi
 
+
+function _print_python_version() {
+   # For some reason python --version writes to stderr
+   if type python > /dev/null; then
+       printf "[%s]\n" "$(python --version 2>&1)"
+   elif type python3 > /dev/null; then
+       printf "[%s]\n" "$(python3 --version 2>&1)"
+   else
+       printf "Unable to find python installed on this machine"
+    fi
+}
+
+
 function _maybeworkon() {
   if [[ -z "$VIRTUAL_ENV" || "$1" != "$(basename $VIRTUAL_ENV)" ]]; then
      if [ -z "$AUTOSWITCH_SILENT" ]; then
@@ -25,14 +38,22 @@ function _maybeworkon() {
      workon "$1"
 
      if [ -z "$AUTOSWITCH_SILENT" ]; then
-       # For some reason python --version writes to stderr
-       if type python > /dev/null; then
-           printf "[%s]\n" "$(python --version 2>&1)"
-       elif type python3 > /dev/null; then
-           printf "[%s]\n" "$(python3 --version 2>&1)"
-       else
-           printf "Unable to find python installed on this machine"
-        fi
+        _print_python_version
+     fi
+  fi
+}
+
+
+function _maybepipenv() {
+  if [[ -z $VIRTUAL_ENV ]]; then
+     if [ -z "$AUTOSWITCH_SILENT" ]; then
+        printf "Switching pipenv: %s  " $(basename $(pipenv --venv))
+     fi
+
+     . $(pipenv --venv)/bin/activate
+
+     if [ -z "$AUTOSWITCH_SILENT" ]; then
+        _print_python_version
      fi
   fi
 }
@@ -94,6 +115,8 @@ function check_venv()
 
         if [[ -n "$SWITCH_TO" ]]; then
           _maybeworkon "$SWITCH_TO"
+        elif [[ -n `pipenv --venv 2>/dev/null` ]]; then
+          _maybepipenv
         else
           _default_venv
         fi

--- a/tests/test_check_venv.zunit
+++ b/tests/test_check_venv.zunit
@@ -116,7 +116,7 @@
 }
 
 
-@test 'check_venv - go to default if .venv available' {
+@test 'check_venv - go to default if .venv unavailable' {
     PWD="$TARGET"
     MYOLDPWD="$(dirname $TARGET)"
     AUTOSWITCH_DEFAULTENV="foodefault"
@@ -128,9 +128,25 @@
 }
 
 
-@test 'check_venv - deactivate if no .venv available' {
+@test 'check_venv - deactivate if .venv unavailable but pipenv available' {
     PWD="$TARGET"
-    MYOLDPWD="$(dirname TARGET)"
+    MYOLDPWD="$(dirname $TARGET)"
+    VIRTUAL_ENV="foo"
+
+    function pipenv {
+        echo "$HOME/.virtualenvs/foobar"
+    }
+
+    run check_venv
+
+    assert $status equals 0
+    assert "$output" same_as "Switching pipenv: foobar  [$PYTHON_VERSION]"
+}
+
+
+@test 'check_venv - deactivate if neither .venv nor pipenv available' {
+    PWD="$TARGET"
+    MYOLDPWD="$(dirname $TARGET)"
     VIRTUAL_ENV="foo"
     unset AUTOSWITCH_DEFAULTENV
     function deactivate {

--- a/tests/test_maybepipenv.zunit
+++ b/tests/test_maybepipenv.zunit
@@ -1,0 +1,62 @@
+#!/usr/bin/env zunit
+
+
+@setup {
+    source =virtualenvwrapper.sh
+
+    echo "Creating test pipenv"
+    run pipenv --python 3
+
+    PYTHON_VERSION="$(python3 --version 2>&1)"
+
+    export DISABLE_AUTOSWITCH_VENV="1"
+    load "../autoswitch_virtualenv.plugin.zsh"
+    TARGET="$(mktemp -d)"
+}
+
+@teardown {
+    rm -rf "$TARGET"
+    run deactivate 2>/dev/null
+    run pipenv --rm
+    rm -rf Pipfile
+}
+
+
+@test '_maybepipenv - switches virtualenv if nothing is activated' {
+    VIRTUAL_ENV=""
+
+    run _maybepipenv "$(pipenv --venv)"
+
+    assert $state equals 0
+    assert "$output" matches "Switching pipenv: $(basename "$PWD")-[^\s]{8}  \[Python 3.6.5\]"
+
+
+}
+
+@test '_maybepipenv - switches virtualenv if current virtualenv is different' {
+    VIRTUAL_ENV="$HOME/.virtualenvs/default_venv"
+
+    run _maybepipenv "$(pipenv --venv)"
+
+    assert $state equals 0
+    assert "$output" matches "Switching pipenv: $(basename "$PWD")-[^\s]{8}  \[Python 3.6.5\]"
+}
+
+@test '_maybepipenv - switches virtualenv if current virtualenv is different (silent)' {
+    VIRTUAL_ENV="$HOME/.virtualenvs/default_venv"
+    AUTOSWITCH_SILENT="1"
+
+    run _maybepipenv "$(pipenv --venv)"
+
+    assert $state equals 0
+    assert "$output" is_empty
+}
+
+@test '_maybepipenv - does not switch to already activated virtualenv' {
+    VIRTUAL_ENV="$(pipenv --venv)"
+
+    run _maybepipenv "$(pipenv --venv)"
+
+    assert $state equals 0
+    assert "$output" is_empty
+}


### PR DESCRIPTION
Previously, though pipenv is activated by pipenv shell or . $(pipenv --venv)/bin/activate, it is soon deactivated when the directory is changed because there are no .venv in any of its paths.

Now, it is able to auto-switch virtual environment not only made by virtualenvwrapper but also pipenv.