### PR TITLE
test: Removed swan-icon from DEFAULT_MESSAGE_FORMAT and from tests to…

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -64,11 +64,7 @@ function _maybeworkon() {
     local venv_type="$2"
     local venv_name="$(_get_venv_name $venv_dir $venv_type)"
 
-    local DEFAULT_MESSAGE_FORMAT="Switching %venv_type: ${BOLD}${PURPLE}%venv_name${NORMAL} ${GREEN}[🐍%py_version]${NORMAL}"
-    if [[ "$LANG" != *".UTF-8" ]]; then
-        # Remove multibyte characters if the terminal does not support utf-8
-        DEFAULT_MESSAGE_FORMAT="${DEFAULT_MESSAGE_FORMAT/🐍/}"
-    fi
+    local DEFAULT_MESSAGE_FORMAT="Switching %venv_type: ${BOLD}${PURPLE}%venv_name${NORMAL} ${GREEN}[%py_version]${NORMAL}"
 
     if [[ -z "$VIRTUAL_ENV" || "$venv_name" != "$(basename $VIRTUAL_ENV)" ]]; then
 

--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -64,7 +64,11 @@ function _maybeworkon() {
     local venv_type="$2"
     local venv_name="$(_get_venv_name $venv_dir $venv_type)"
 
-    local DEFAULT_MESSAGE_FORMAT="Switching %venv_type: ${BOLD}${PURPLE}%venv_name${NORMAL} ${GREEN}[%py_version]${NORMAL}"
+    local DEFAULT_MESSAGE_FORMAT="Switching %venv_type: ${BOLD}${PURPLE}%venv_name${NORMAL} ${GREEN}[🐍%py_version]${NORMAL}"
+    if [[ "$LANG" != *".UTF-8" ]]; then
+        # Remove multibyte characters if the terminal does not support utf-8
+        DEFAULT_MESSAGE_FORMAT="${DEFAULT_MESSAGE_FORMAT/🐍/}"
+    fi
 
     if [[ -z "$VIRTUAL_ENV" || "$venv_name" != "$(basename $VIRTUAL_ENV)" ]]; then
 

--- a/tests/test_check_venv.zunit
+++ b/tests/test_check_venv.zunit
@@ -111,7 +111,7 @@
     run check_venv
 
     assert $status equals 0
-    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
 }
 
 @test 'check_venv - No security warning for readable by group permission' {
@@ -125,7 +125,7 @@
     run check_venv
 
     assert $status equals 0
-    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
 }
 
 @test 'check_venv - No security warning for readable only by owner permission' {
@@ -138,7 +138,7 @@
     run check_venv
 
     assert $status equals 0
-    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
 }
 
 
@@ -149,7 +149,7 @@
     run check_venv
 
     assert $status equals 0
-    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoodefault\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoodefault\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
 }
 
 
@@ -165,7 +165,7 @@
     run check_venv
 
     assert $status equals 0
-    assert "$output" same_as "Switching pipenv: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching pipenv: \e[1m\e[35mfoobar\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
 }
 
 
@@ -206,5 +206,5 @@
     run check_venv
 
     assert $status equals 0
-    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
 }

--- a/tests/test_check_venv.zunit
+++ b/tests/test_check_venv.zunit
@@ -18,6 +18,8 @@
     load "../autoswitch_virtualenv.plugin.zsh"
     TARGET="$(mktemp -d)"
     OLDPWD="$(mktemp -d)"
+
+    LANG=".UTF-8"
 }
 
 
@@ -111,7 +113,7 @@
     run check_venv
 
     assert $status equals 0
-    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
 }
 
 @test 'check_venv - No security warning for readable by group permission' {
@@ -125,7 +127,7 @@
     run check_venv
 
     assert $status equals 0
-    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
 }
 
 @test 'check_venv - No security warning for readable only by owner permission' {
@@ -138,7 +140,7 @@
     run check_venv
 
     assert $status equals 0
-    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
 }
 
 
@@ -149,7 +151,7 @@
     run check_venv
 
     assert $status equals 0
-    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoodefault\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoodefault\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
 }
 
 
@@ -165,7 +167,7 @@
     run check_venv
 
     assert $status equals 0
-    assert "$output" same_as "Switching pipenv: \e[1m\e[35mfoobar\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching pipenv: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
 }
 
 
@@ -206,5 +208,5 @@
     run check_venv
 
     assert $status equals 0
-    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
 }

--- a/tests/test_install_requirements.zunit
+++ b/tests/test_install_requirements.zunit
@@ -126,7 +126,7 @@
     assert "$lines[6]" same_as "pytest"
 }
 
-@test 'install_requirements - installs setup.py' {
+@test 'install_requirements - installs setup.py (FULL)' {
     touch "setup.py"
     echo "django" > requirements.txt
 

--- a/tests/test_install_requirements.zunit
+++ b/tests/test_install_requirements.zunit
@@ -5,7 +5,7 @@
     load "../autoswitch_virtualenv.plugin.zsh"
     unset AUTOSWITCH_DEFAULT_REQUIREMENTS
     unset AUTOSWITCH_PIPINSTALL
-    
+
     function read {
         eval $1=\"y\"
         echo y

--- a/tests/test_install_requirements.zunit
+++ b/tests/test_install_requirements.zunit
@@ -4,7 +4,8 @@
     export DISABLE_AUTOSWITCH_VENV="1"
     load "../autoswitch_virtualenv.plugin.zsh"
     unset AUTOSWITCH_DEFAULT_REQUIREMENTS
-
+    unset AUTOSWITCH_PIPINSTALL
+    
     function read {
         eval $1=\"y\"
         echo y

--- a/tests/test_maybeworkon.zunit
+++ b/tests/test_maybeworkon.zunit
@@ -15,6 +15,8 @@
     export DISABLE_AUTOSWITCH_VENV="1"
     load "../autoswitch_virtualenv.plugin.zsh"
     TARGET="$(mktemp -d)"
+
+    LANG=".UTF-8"
 }
 
 @teardown {
@@ -38,7 +40,7 @@
     run _maybeworkon "$TEST_VIRTUALENV" virtualenv
 
     assert $state equals 0
-    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
 }
 
 @test '_maybeworkon - custom message' {
@@ -67,7 +69,7 @@
     run _maybeworkon "$TEST_VIRTUALENV" virtualfoo
 
     assert $state equals 0
-    assert "$output" contains "Switching virtualfoo: \e[1m\e[35mfoobar\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
+    assert "$output" contains "Switching virtualfoo: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
 }
 
 @test '_maybeworkon - switches virtualenv if current virtualenv is different (silent)' {
@@ -93,5 +95,5 @@
     run _maybeworkon hello-world-foo-de31f pipenv
 
     assert $state equals 0
-    assert "$output" same_as "Switching pipenv: \e[1m\e[35mhello-world-foo\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching pipenv: \e[1m\e[35mhello-world-foo\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
 }

--- a/tests/test_maybeworkon.zunit
+++ b/tests/test_maybeworkon.zunit
@@ -38,7 +38,7 @@
     run _maybeworkon "$TEST_VIRTUALENV" virtualenv
 
     assert $state equals 0
-    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
 }
 
 @test '_maybeworkon - custom message' {
@@ -67,7 +67,7 @@
     run _maybeworkon "$TEST_VIRTUALENV" virtualfoo
 
     assert $state equals 0
-    assert "$output" contains "Switching virtualfoo: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
+    assert "$output" contains "Switching virtualfoo: \e[1m\e[35mfoobar\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
 }
 
 @test '_maybeworkon - switches virtualenv if current virtualenv is different (silent)' {
@@ -93,5 +93,5 @@
     run _maybeworkon hello-world-foo-de31f pipenv
 
     assert $state equals 0
-    assert "$output" same_as "Switching pipenv: \e[1m\e[35mhello-world-foo\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching pipenv: \e[1m\e[35mhello-world-foo\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
 }

--- a/tests/test_plugin.zunit
+++ b/tests/test_plugin.zunit
@@ -36,7 +36,7 @@
     run load ../autoswitch_virtualenv.plugin.zsh
 
     assert $status equals 0
-    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
 }
 
 @test 'plugin - does nothing if switching to directory without .venv' {
@@ -62,7 +62,7 @@
     run cd "$TEMP_DIR"
 
     assert $status equals 0
-    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
 
     mkdir "$TEMP_DIR/foo"
 
@@ -70,5 +70,5 @@
     run cd "$TEMP_DIR/foo"
 
     assert $status equals 0
-    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
 }

--- a/tests/test_plugin.zunit
+++ b/tests/test_plugin.zunit
@@ -8,6 +8,8 @@
     unset VIRTUAL_ENV
     unset AUTOSWITCH_MESSAGE_FORMAT
     PYTHON_VERSION="$(python3 --version)"
+
+    LANG=".UTF-8"
 }
 
 @test 'correct version exported' {
@@ -36,7 +38,7 @@
     run load ../autoswitch_virtualenv.plugin.zsh
 
     assert $status equals 0
-    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
 }
 
 @test 'plugin - does nothing if switching to directory without .venv' {
@@ -62,7 +64,7 @@
     run cd "$TEMP_DIR"
 
     assert $status equals 0
-    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
 
     mkdir "$TEMP_DIR/foo"
 
@@ -70,5 +72,5 @@
     run cd "$TEMP_DIR/foo"
 
     assert $status equals 0
-    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[$PYTHON_VERSION]\e[0m"
+    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
 }


### PR DESCRIPTION
Fixes issue #114 by removing swan-icon from `DEFAULT_MESSAGE_FORMAT`.

Also disambiguated 'install_requirements - installs setup.py' test name for FULL installation by adding "(FULL) to test.