### PR TITLE
local var declaration and assignment

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -254,7 +254,8 @@ function mkvenv()
         printf "Creating ${PURPLE}%s${NONE} virtualenv\n" "$venv_name"
 
         # Copy parameters variable so that we can mutate it
-        local params=("${@[@]}")
+        local params
+        params=("${@[@]}")
 
         if [[ -n "$AUTOSWITCH_DEFAULT_PYTHON" && ${params[(I)--python*]} -eq 0 ]]; then
             params+="--python=$AUTOSWITCH_DEFAULT_PYTHON"


### PR DESCRIPTION
## Problem

When mkvenv is run on zsh version 5.0.2 (and I believe up to 5.1), the following error occurs:
```bash
➜  new_project mkvenv
Creating new_project virtualenv
mkvenv:20: no matches found: params=()
➜  new_project mkvenv --verbose
Creating new_project virtualenv
mkvenv:20: unknown file attribute
```

I think this is because it wasn't until zsh 5.1 implemented reserved words for builtins (local) that allow for declaration and assignment on the same line. This seems to only affect the line with positional argument variables.

This is a pretty old zsh version to worry about, but it is still the only one provided for CentOS 7.

## Reproduce

I couldn't find how to install older versions of zsh, but it's easy enough to use [vagrant](https://www.vagrantup.com/) to install CentOS 7, which will install zsh 5.0.2.

```
Vagrant.configure("2") do |config|
  config.vm.define "centos" do |centos|
    centos.vm.box = "bento/centos-7"
    centos.vm.hostname = "centos"
    centos.vm.provision "shell", inline: "sudo yum -y install zsh"
    centos.vm.provision "shell", inline: "/bin/zsh --version"
  end
end
```
(then set up the zsh-autoswitch-virtualenv plugin)

## Fix

Declaring var on one line and assignment on the next for only positional arguments.

## Tests

```
➜  zsh-autoswitch-virtualenv git:(local_var_bug) zunit 
Launching ZUnit
ZUnit: 0.8.2
ZSH:   zsh 5.0.2 (x86_64-redhat-linux-gnu)

✔ _check_path - test finds in base directory                             
✔ _check_path - returns nothing if not found                             
✔ _check_path - finds in parent directories                              
✔ _check_path - returns nothing with root path                           
                    ⠹ check_venv - Displays message on project detection                     ⠸ check_venv - Displays message on project detection                     ⠼ check_venv - Displays message on project detection                     ⠴ check_venv - Displays message on project detection                     ⠦ check_venv - Displays message on project detection                     ⠧ check_venv - Displays message on project detection                     ⠇ check_venv - Displays message on project detection                     ⠏ check_venv - Displays message on project detection                     ⠋ check_venv - Displays message on project detection                     ⠙ check_venv - Displays message on project detection                     ⠹ check_venv - Displays message on project detection                     ⠸ check_venv - Displays message on project detection                     ⠼ check_venv - Displays message on project detection                     ⠴ check_venv - Displays message on project detection                     ⠦ check_venv - Displays message on project detection                     ⠧ check_venv - Displays message on project detection                     ⠇ check_venv - Displays message on project detection                     ⠏ check_venv - Displays message on project detection                     ⠋ check_venv - Displays message on project detection                     ⠙ check_venv - Displays message on project detection                     ⠹ check_venv - Displays message on project detection                     ⠸ check_venv - Displays message on project detection                     ⠼ check_venv - Displays message on project detection                     ⠴ check_venv - Displays message on project detection                     ⠦ check_venv - Displays message on project detection                     ⠧ check_venv - Displays message on project detection                     ⠇ check_venv - Displays message on project detection                     ⠏ check_venv - Displays message on project detection                     ⠋ check_venv - Displays message on project detection                     ⠙ check_venv - Displays message on project detection                     ⠹ check_venv - Displays message on project detection                     ⠸ check_venv - Displays message on project detection                     ⠼ check_venv - Displays message on project detection                     ⠴ check_venv - Displays message on project detection                     ⠦ check_venv - Displays message on project detection                     ⠧ check_venv - Displays message on project detection                     ⠇ check_venv - Displays message on project detection                     ⠏ check_venv - Displays message on project detection                     ⠋ check_venv - Displays message on project detection                     ⠙ check_venv - Displays message on project detection                     ⠹ check_venv - Displays message on project detection                     ⠸ check_venv - Displays message on project detection                     ⠼ check_venv - Displays message on project detection                     ⠴ check_venv - Displays message on project detection                     ⠦ check_venv - Displays message on project detection                     ⠧ check_venv - Displays message on project detection                     ⠇ check_venv - Displays message on project detection                     ⠏ check_venv - Displays message on project detection                     ⠋ check_venv - Displays message on project detection ✔ check_venv - Displays message on project detection (requirements.txt)
✔ check_venv - Displays message on project detection (setup.py)n (setup. 
✔ check_venv - Displays message on project detection (Pipfile)n (Pipfil  
                               ⠸ check_venv - Displays message on project✔ check_venv - Displays message on project detection (setup.py + requirements.txt)
✔ check_venv - Security warning for weak writeable by group permissions  
                       ⠼ check_venv - Security warning for weak writeable✔ check_venv - Security warning for weak writeable by everyone permissions
                   ⠴ check_venv - No security warning for readable by eve✔ check_venv - No security warning for readable by everyone permission
                ⠦ check_venv - No security warning for readable by group ✔ check_venv - No security warning for readable by group permission
                     ⠧ check_venv - No security warning for readable only✔ check_venv - No security warning for readable only by owner permission
✔ check_venv - go to default if .venv unavailable                        
✔ check_venv - activate if .venv unavailable but pipenv available        
✔ check_venv - deactivate if neither .venv nor pipenv availablenv availa 
                                     ⠋ check_venv - deactivate if neither✔ check_venv - deactivate if neither .venv nor pipenv available (previous dir is pipenv)
✔ check_venv - works as intended with .venv availablele                  
✔ _get_venv_type pipenv                                                  
✔ _get_venv_type virtualenv (requirements.txt)                           
✔ _get_venv_type virtualenv (setup.py)                                   
✔ _get_venv_type virtualenv (default)                                    
✔ _get_venv_type virtualenv (default specified)                          
✔ install_requirements - does nothing if no files foundound              
✔ install_requirements - does not install with no input                  
✔ install_requirements - installs default requirements                   
✔ install_requirements - installs *requirements.txt                      
✔ install_requirements - installs setup.py                               
✔ install_requirements - installs recursive *requirements.txt            
✔ install_requirements - installs setup.py (FULL)                        
✔ _maybeworkon - do not activate paths which are potentially inscure     
✔ _maybeworkon - error message if virtualenv can not be foundt be foun   
✔ _maybeworkon - switches virtualenv if nothing is activatedactivated    
✔ _maybeworkon - custom message                                          
✔ _maybeworkon - no emoji on non utf-8 LANG                              
                    ⠏ _maybeworkon - switches virtualenv if current virtu✔ _maybeworkon - switches virtualenv if current virtualenv is different
                             ⠋ _maybeworkon - switches virtualenv if curr✔ _maybeworkon - switches virtualenv if current virtualenv is different (silent)
✔ _maybeworkon - does not switch to already activated virtualenv         
✔ mkvenv - does not create .venv if one exists                           
✔ mkvenv - creates .venv                                                 
✔ mkvenv - uses default python if set and not specifiedfied              
✔ mkvenv - uses specified python if default set                          
✔ prints help message and disables plugin if virtualenv not setup        
✔ correct version exported                                               
✔ plugin - does nothing on load if no default set                        
✔ plugin - runs default env on load                                      
✔ plugin - does nothing if switching to directory without .venv          
✔ plugin - switches env when .venv found                                 
✔ rmvenv - shows warning if no .venv present                             
✔ rmvenv - removes .venv if present                                      
✔ rmvenv - removes .venv if present with function                        
✔ rmvenv - removes .venv and deactivates if currently actively active    

52 tests run in 15s 75ms

Results                        
✔ Passed      52                    
✘ Failed      0                      
‼ Errors      0                      
● Skipped     0                 
‼ Warnings    0                 
```