### PR TITLE
Silence spurious errors from dirname

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -187,9 +187,11 @@ function check_venv()
         # we need to infer the target virtualenv directory based on poetry's data
         # to easiest way is to actually get the location of the python binary and
         # infer the location of the virtualenv from there.
-        if venv_path="$(dirname $(dirname $(poetry run which python)))"; then
-            _maybeworkon "$venv_path" "poetry"
-            return
+        if poetry_python=$(poetry run which python); then
+            if venv_path="$(dirname $(dirname $poetry_python))"; then
+                _maybeworkon "$venv_path" "poetry"
+                return
+            fi
         fi
     fi
 

--- a/tests/test_check_venv.zunit
+++ b/tests/test_check_venv.zunit
@@ -167,6 +167,15 @@
 
     assert $status equals 0
     assert "$output" same_as "Switching poetry: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
+
+    # poetry available, but "poetry run which python" fails because pyproject.toml doesn't use poetry
+    function poetry {
+        return 1
+    }
+
+    run check_venv
+    assert $status equals 0
+    assert "$output" is_empty
 }
 
 


### PR DESCRIPTION
If the poetry executable and a pyproject.toml exist, but the project we're in doesn't use poetry, the two dirname calls spit out an annoying "usage: dirname path" every time we cd.