### PR TITLE
Poetry in project issue

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -142,17 +142,9 @@ function _check_path()
 function _activate_poetry() {
     # check if any environments exist before trying to activate
     # if env list is empty, then no environment exists that can be activated
-    name="$(poetry env list | cut -d' ' -f1)"
+    local name="$(poetry env list --full-path | cut -d' ' -f1)"
     if [[ -n "$name" ]]; then
-        local venv_path
-        # Temporary work around until we figure out a better way to
-        # correctly determine the location of virtualenvs in poetry
-        if [[ "$(uname)" == "Darwin" ]]; then
-            venv_path="$HOME/Library/Caches/pypoetry/virtualenvs/$name"
-        else
-            venv_path="$HOME/.cache/pypoetry/virtualenvs/$name"
-        fi
-        _maybeworkon "$venv_path" "poetry"
+        _maybeworkon "$name" "poetry"
         return 0
     fi
     return 1
@@ -177,7 +169,7 @@ function check_venv()
 
     # Get the $AUTOSWITCH_FILE, scanning parent directories
     local venv_path="$(_check_path "$PWD")"
-
+    
     if [[ -n "$venv_path" ]]; then
 
         /usr/bin/stat --version &> /dev/null

--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -169,7 +169,7 @@ function check_venv()
 
     # Get the $AUTOSWITCH_FILE, scanning parent directories
     local venv_path="$(_check_path "$PWD")"
-    
+
     if [[ -n "$venv_path" ]]; then
 
         /usr/bin/stat --version &> /dev/null

--- a/tests/test_check_venv.zunit
+++ b/tests/test_check_venv.zunit
@@ -176,9 +176,9 @@
     PWD="$TARGET/sub-directory"  # Should also work in subdirectories where poetry.lock is found
     touch "$TARGET/poetry.lock"
 
-    # Mimic "poetry env list"
+    # Mimic "poetry env list --full-path"
     function poetry {
-        echo "poetry-foo (activated)"
+        echo "$HOME/.cache/pypoetry/virtualenvs/poetry-foo (Activated)"
     }
 
     run check_venv


### PR DESCRIPTION
Closes MichaelAquilina/zsh-autoswitch-virtualenv#138
This replaces the poetry venv location guessing by getting the full venv path from poetry itself.

This probably clashes with MichaelAquilina/zsh-autoswitch-virtualenv#136