### PR TITLE
Avoid name conflicts when generating new virtualenv via `mkvenv`

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -315,7 +315,9 @@ function mkvenv()
         if [[ -f "$AUTOSWITCH_FILE" ]]; then
             printf "$AUTOSWITCH_FILE file already exists. If this is a mistake use the rmvenv command\n"
         else
-            local venv_name="$(basename $PWD)"
+            # If the mkvenv command is executed in '/home/user/my-project', the name of the virtualenv
+            # will be 'my-project-wyUf‘ where the last 4 characters are random letters of mixed case
+            local venv_name="$(basename $PWD)-$(base64 </dev/urandom | tr -dc 'a-zA-Z' | head -c4)"
 
             printf "Creating ${PURPLE}%s${NONE} virtualenv\n" "$venv_name"
 


### PR DESCRIPTION
When using `mkvenv` in a directory '/home/user/my-project' where a virtualenv hasn't been created yet, currently a virtualenv with the name 'my-project' is created in '~/.virtualenvs'. The problem is: If you have two projects bearing the same folder name, e.g. /home/user/projects/2020/my-project and /home/user/python/my-project, running `mkvenv` in both folders will attach them to the same virtualenv (without any warning) and completely mess up their environments. I think it is quite common to occasionally name two project folders the same, especially if you start over with a project.

Pipenv solves the same issue by appending a 8 character hash to the directory name. I implemented something similar, but appended only 4 characters (e.g. 'my-project-yKzA', because it takes up less place in the shell prompt and is most likely enough to avoid conflicts, but we increase it to 8 if you prefer to have it look similar to the style of pipenv.

This won't affect anyone using already existing environments or adding environments that were created with pipenv/poetry etc. It will only apply when an entirely new environment is generated. So it shouldn't break anything for existing users. 