### PR TITLE
Fix the oh-my-zsh installation documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Zgen_
 
 oh-my-zsh_
 
-Copy this repository to ``$ZSH_CUSTOM/custom/plugins``, where ``$ZSH_CUSTOM``
+Copy this repository to ``$ZSH_CUSTOM/plugins``, where ``$ZSH_CUSTOM``
 is the directory with custom plugins of oh-my-zsh `(read more) <https://github.com/robbyrussell/oh-my-zsh/wiki/Customization/>`_:
 
 ::


### PR DESCRIPTION
It was set as `$ZSH_CUSTOM/custom/plugins` but `$ZSH_CUSTOM` includes the `/custom` part