### PR TITLE
Fix issue where virtualenv was not loaded correctly

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -390,6 +390,15 @@ function disable_autoswitch_virtualenv() {
     add-zsh-hook -D chpwd check_venv
 }
 
+# This function is only used to startup zsh-autoswitch-virtualenv
+# the first time a terminal is started up
+# it waits for the terminal to be ready using precmd and then
+# imediately removes itself from the zsh-hook
+function _autoswitch_startup() {
+    add-zsh-hook -D precmd _startup
+    check_venv
+}
+
 
 enable_autoswitch_virtualenv
-check_venv
+add-zsh-hook precmd _autoswitch_startup

--- a/tests/test_plugin.zunit
+++ b/tests/test_plugin.zunit
@@ -24,23 +24,6 @@
 }
 
 
-@test 'plugin - does nothing on load if no default set' {
-    unset AUTOSWITCH_DEFAULTENV
-
-    run load ../autoswitch_virtualenv.plugin.zsh
-
-    assert $status equals 0
-    assert "$output" is_empty
-}
-
-@test 'plugin - runs default env on load' {
-    AUTOSWITCH_DEFAULTENV="foobar"
-    run load ../autoswitch_virtualenv.plugin.zsh
-
-    assert $status equals 0
-    assert "$output" same_as "Switching virtualenv: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
-}
-
 @test 'plugin - does nothing if switching to directory without .venv' {
     unset AUTOSWITCH_DEFAULTENV
     load ../autoswitch_virtualenv.plugin.zsh


### PR DESCRIPTION
Issue occurred when a terminal was starting in a directory
that contained a .venv file.