### PR TITLE
feat: Update mkvenv to generate virtualenvs that dont shadow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,16 @@ test: &test
     - checkout
     - run:
         name: Install Dependencies
-        command: apt-get update && apt-get install -y curl python3-pip ncurses-bin python python-virtualenv git
+        command: >
+          apt-get update &&
+          apt-get install -y
+          python3-pip
+          python
+          python-virtualenv
+          curl
+          ncurses-bin
+          git
+          pwgen
     - run:
         name: install pipenv
         command: pip3 install pipenv

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ projects (or equivalent file for the Version Control you are using).
 Installing
 ----------
 
-``autoswitch-virtualenv`` requires `virtualenv <https://pypi.org/project/virtualenv/>`__ to be installed.
+``autoswitch-virtualenv`` requires `virtualenv <https://pypi.org/project/virtualenv/>`__ and ``pwgen`` to be installed.
 
 Once ``virtualenv`` is installed, add one of the following lines to your ``.zshrc`` file depending on the
 package manager you are using:

--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -315,7 +315,7 @@ function mkvenv()
         if [[ -f "$AUTOSWITCH_FILE" ]]; then
             printf "$AUTOSWITCH_FILE file already exists. If this is a mistake use the rmvenv command\n"
         else
-            local venv_name="$(basename $PWD)"
+            local venv_name="$(basename $PWD)-$(pwgen 8 1)"
 
             printf "Creating ${PURPLE}%s${NONE} virtualenv\n" "$venv_name"
 

--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -321,6 +321,10 @@ function mkvenv()
 
 
             if [[ -n "$AUTOSWITCH_DEFAULT_PYTHON" && ${params[(I)--python*]} -eq 0 ]]; then
+                printf "${PURPLE}"
+                printf 'Using $AUTOSWITCH_DEFAULT_PYTHON='
+                printf "$AUTOSWITCH_DEFAULT_PYTHON"
+                printf "${NONE}\n"
                 params+="--python=$AUTOSWITCH_DEFAULT_PYTHON"
             fi
 

--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -7,7 +7,6 @@ PURPLE="\e[35m"
 BOLD="\e[1m"
 NORMAL="\e[0m"
 
-
 function _validated_source() {
     local target_path="$1"
 
@@ -384,7 +383,6 @@ function install_requirements() {
 
 
 function enable_autoswitch_virtualenv() {
-    autoload -Uz add-zsh-hook
     disable_autoswitch_virtualenv
     add-zsh-hook chpwd check_venv
 }
@@ -397,12 +395,18 @@ function disable_autoswitch_virtualenv() {
 # This function is only used to startup zsh-autoswitch-virtualenv
 # the first time a terminal is started up
 # it waits for the terminal to be ready using precmd and then
-# imediately removes itself from the zsh-hook
+# immediately removes itself from the zsh-hook.
+# This seems important for "instant prompt" zsh themes like powerlevel10k
 function _autoswitch_startup() {
     add-zsh-hook -D precmd _startup
-    check_venv
+
+    if ! type pwgen 1>/dev/null; then
+        printf "${PURPLE}pwgen is required for zsh-autoswitch-virtualenv to run${NONE}\n"
+    else
+        enable_autoswitch_virtualenv
+        check_venv
+    fi
 }
 
-
-enable_autoswitch_virtualenv
+autoload -Uz add-zsh-hook
 add-zsh-hook precmd _autoswitch_startup

--- a/tests/test_mkvenv.zunit
+++ b/tests/test_mkvenv.zunit
@@ -50,12 +50,11 @@
 
     assert $status equals 0
     assert "$TARGET/myproject/.venv" exists
-    # assert "$lines[1]" same_as "Creating \e[35mmyproject\e[0m virtualenv"
 
     run cat "$TARGET/myproject/.venv"
 
     assert $status equals 0
-    assert "$output" same_as "myproject"
+    assert "$output" matches "myproject-[a-zA-Z0-9]{8}"
 }
 
 @test 'mkvenv - (poetry project) runs correct command' {
@@ -92,12 +91,14 @@
     assert $status equals 0
     assert "$TARGET/myproject/.venv" exists
     # Assert mock output
-    assert "$lines[2]" same_as "virtualenv --python=python_foo $HOME/.virtualenvs/myproject"
+
+    expected="virtualenv --python=python_foo $HOME/.virtualenvs/myproject-"
+    assert "$lines[2]" contains "$expected"
 
     run cat "$TARGET/myproject/.venv"
 
     assert $status equals 0
-    assert "$output" same_as "myproject"
+    assert "$output" matches "myproject-[a-zA-Z0-9]{8}"
 }
 
 @test 'mkvenv - uses specified python if default set' {
@@ -115,12 +116,12 @@
     assert $status equals 0
     assert "$TARGET/myproject/.venv" exists
     # Assert mock output
-    assert "$lines[2]" same_as "virtualenv --python=python_bar $HOME/.virtualenvs/myproject"
+    assert "$lines[2]" contains "virtualenv --python=python_bar $HOME/.virtualenvs/myproject-"
 
     run cat "$TARGET/myproject/.venv"
 
     assert $status equals 0
-    assert "$output" same_as "myproject"
+    assert "$output" matches "myproject-[a-zA-Z0-9]{8}"
 }
 
 @test 'prints help message and disables plugin if virtualenv not setup' {

--- a/tests/test_mkvenv.zunit
+++ b/tests/test_mkvenv.zunit
@@ -92,8 +92,10 @@
     assert "$TARGET/myproject/.venv" exists
     # Assert mock output
 
-    expected="virtualenv --python=python_foo $HOME/.virtualenvs/myproject-"
+    expected='Using $AUTOSWITCH_DEFAULT_PYTHON=python_foo'
     assert "$lines[2]" contains "$expected"
+    expected="virtualenv --python=python_foo $HOME/.virtualenvs/myproject-"
+    assert "$lines[3]" contains "$expected"
 
     run cat "$TARGET/myproject/.venv"
 

--- a/tests/test_plugin.zunit
+++ b/tests/test_plugin.zunit
@@ -39,6 +39,9 @@
 @test 'plugin - switches env when .venv found' {
     unset AUTOSWITCH_DEFAULTENV
     load ../autoswitch_virtualenv.plugin.zsh
+    # zsh-hook precmd does not seem to work correctly in tests
+    # so we need to manually enable the plugin
+    enable_autoswitch_virtualenv
 
     TEMP_DIR="$(mktemp -d)"
     echo "foobar" > "$TEMP_DIR/.venv"

--- a/tests/test_rmvenv.zunit
+++ b/tests/test_rmvenv.zunit
@@ -68,11 +68,12 @@
 @test 'rmvenv - removes .venv and deactivates if currently active' {
     test_venv="$(basename $PWD)"
     run mkvenv
+    target_venv="$(<.venv)"
 
     run rmvenv
 
     assert $state equals 0
-    assert "$output" same_as "Removing \e[35m$test_venv\e[0m..."
+    assert "$output" same_as "Removing \e[35m$target_venv\e[0m..."
     test ! -f .venv
     test ! -d "$HOME/.virtualenvs/$test_venv"
 }


### PR DESCRIPTION
TODO:
- [x] Is if safe to assume every system has `pwgen`? We could always just ask that its installed