### PR TITLE
`poetry env list` is slow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ test: &test
         name: install pipenv
         command: pip3 install pipenv
     - run:
+        name: install poetry
+        command: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+    - run:
         name: Download Zunit
         command: |
           mkdir -p ~/bin
@@ -33,7 +36,7 @@ test: &test
           export LC_ALL=C.UTF-8
           export LANG=C.UTF-8
           export TERM="xterm-256color"  # Required by tput
-          export PATH="$HOME/bin:$PATH"
+          export PATH="$HOME/bin:$HOME/.poetry/bin:$PATH"
           zunit --verbose
 
 

--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -141,7 +141,7 @@ function _check_path()
 function _activate_poetry() {
     # check if any environments exist before trying to activate
     # if env list is empty, then no environment exists that can be activated
-    local name="$(poetry env list --full-path | sort -k 2 | tail -n 1 | cut -d' ' -f1)"
+    local name="${VIRTUAL_ENV:-$(poetry env list --full-path | sort -k 2 | tail -n 1 | cut -d' ' -f1)}"
     if [[ -n "$name" ]]; then
         _maybeworkon "$name" "poetry"
         return 0

--- a/tests/test_check_venv.zunit
+++ b/tests/test_check_venv.zunit
@@ -187,6 +187,31 @@
     assert "$output" same_as "Switching poetry: \e[1m\e[35mpoetry-foo\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
 }
 
+@test 'check_venv - bypass poetry call because already activated and VIRTUAL_ENV is set' {
+    PWD="$TARGET/sub-directory"  # Should also work in subdirectories where poetry.lock is found
+    touch "$TARGET/poetry.lock"
+
+    function poetry {
+        echo "$HOME/.cache/pypoetry/virtualenvs/some-other-env\n$HOME/.cache/pypoetry/virtualenvs/poetry-foo (Activated)"
+    }
+
+    # when check_venv is successful, then the variable VIRTUAL_ENV should be set and should be used intended
+    # subsequent calls to check_venv
+    run check_venv
+    assert $status equals 0
+    assert "$output" same_as "Switching poetry: \e[1m\e[35mpoetry-foo\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
+
+    # unset poetry function because it should no longer be needed because VIRUAL_ENV is set
+    # will fail here and not find the poetry command if VIRTUAL_ENV isn't set
+    unset -f poetry
+    for i in {1..3}; do
+        run check_venv
+        assert $status equals 0
+        assert "$output" is_empty
+    done
+}
+
+
 @test 'check_venv - activate if .venv unavailable but pipenv available' {
     PWD="$TARGET/sub-directory"  # Should also work in subdirectories where Pipfile is found
     touch "$TARGET/Pipfile"
@@ -200,8 +225,6 @@
     assert $status equals 0
     assert "$output" same_as "Switching pipenv: \e[1m\e[35mfoobar\e[0m \e[32m[🐍$PYTHON_VERSION]\e[0m"
 }
-
-
 @test 'check_venv - deactivate if neither .venv nor pipenv available' {
     PWD="$TARGET"
     VIRTUAL_ENV="foo"


### PR DESCRIPTION
I was frustrated with why on almost every command I do in a poetry project(ls, exa, vi a file then exit) there is a large time penalty.

I put in some basic time measurement around the `poetry env list` command and it was, on average, taking 600ms. This was quite frustrating. I'm not certain why it's so slow but it is.

This change adds the use of the `VIRTUAL_ENV` environment variable if it exists else it using `poetry env list`. `VIRTUAL_ENV` isn't there until the first call to `activate` so we have to pay the `poetry env list` penalty at least once.

`VIRTUAL_ENV` is also checked in the `_maybeworkon` call, and the `_activate_poetry` call is only used to indicate if a message might be printed and if the `_default_env` should be used. Perhaps a better change would be to have `_maybeworkon` return a value that can be used to indicate if `mkvenv` should be run or something.