### PR TITLE
Fix slow prompt in pipenv and poetry environments

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -398,7 +398,7 @@ function disable_autoswitch_virtualenv() {
 # immediately removes itself from the zsh-hook.
 # This seems important for "instant prompt" zsh themes like powerlevel10k
 function _autoswitch_startup() {
-    add-zsh-hook -D precmd _startup
+    add-zsh-hook -D precmd _autoswitch_startup
 
     if ! type pwgen 1>/dev/null; then
         printf "${PURPLE}pwgen is required for zsh-autoswitch-virtualenv to run${NONE}\n"


### PR DESCRIPTION
`_autoswitch_startup` was not actually removing itself from the precmd hook.

Should supersede #158 and close #159.