### PR TITLE
docs: Document that 'python' needs to be available in '$PATH'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,7 @@ Installing
 ----------
 
 ``autoswitch-virtualenv`` requires `virtualenv <https://pypi.org/project/virtualenv/>`__ to be installed.
+You will also need to make sure that ``python`` (without a suffix; both Python 2 and 3 are supported) is available in your ``$PATH``.
 
 Once ``virtualenv`` is installed, add one of the following lines to your ``.zshrc`` file depending on the
 package manager you are using:


### PR DESCRIPTION
Document that a 'python' (without a version suffix like 'python3') needs to be
available in '$PATH' for the plugin to work.

This is a follow-up to #171 and #172.