### PR TITLE
Deactivate Conda environment before virtualenv activation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -318,6 +318,16 @@ By default `mkvenv` will install setup.py via pip in `editable (i.e. development
 <https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs>`__.
 To change this set ``AUTOSWITCH_PIPINSTALL`` to ``FULL``.
 
+**Deactivating active Conda environment**
+
+By default, virtual environments are activated without checking if any Conda environment is active.
+When one is, your prompt may display information about virtualenv being active, but in reality
+the Conda environment will still be used.
+
+To avoid such confusing behaviour, you can have the Conda environment deactivated automatically
+(and then switched back when leaving the directory), set the value of the environment variable
+``AUTOSWITCH_DEACTIVATE_CONDA`` to a non-empty value.
+
 Security Warnings
 -----------------
 

--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -236,6 +236,11 @@ function _default_venv()
         local venv_name="$(_get_venv_name "$VIRTUAL_ENV" "$venv_type")"
         _autoswitch_message "Deactivating: ${BOLD}${PURPLE}%s${NORMAL}\n" "$venv_name"
         deactivate
+        
+        if [[ ! -z "$AUTOSWITCH_DEACTIVATED_CONDA_ENV" ]]; then
+            conda activate $AUTOSWITCH_DEACTIVATED_CONDA_ENV
+            unset AUTOSWITCH_DEACTIVATED_CONDA_ENV
+        fi
     fi
 }
 

--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -108,6 +108,11 @@ function _maybeworkon() {
             export PIPENV_VERBOSITY=-1
         fi
 
+        if [[ ! -z "$CONDA_DEFAULT_ENV" ]]; then
+            export AUTOSWITCH_DEACTIVATED_CONDA_ENV=$CONDA_DEFAULT_ENV
+            conda deactivate
+        fi
+
         # Much faster to source the activate file directly rather than use the `workon` command
         local activate_script="$venv_dir/bin/activate"
 

--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -95,7 +95,7 @@ function _maybeworkon() {
             return
         fi
 
-        if [[ ! -z "$CONDA_DEFAULT_ENV" ]]; then
+        if [[ ! -z "$AUTOSWITCH_DEACTIVATE_CONDA" ]] && [[ ! -z "$CONDA_DEFAULT_ENV" ]]; then
             _autoswitch_message "Deactivating Conda env: ${BOLD}${GREEN}%s${NORMAL}\n" "$CONDA_DEFAULT_ENV"
             export AUTOSWITCH_DEACTIVATED_CONDA_ENV=$CONDA_DEFAULT_ENV
             conda deactivate
@@ -238,7 +238,7 @@ function _default_venv()
         _autoswitch_message "Deactivating: ${BOLD}${PURPLE}%s${NORMAL}\n" "$venv_name"
         deactivate
 
-        if [[ ! -z "$AUTOSWITCH_DEACTIVATED_CONDA_ENV" ]]; then
+        if [[ ! -z "$AUTOSWITCH_DEACTIVATE_CONDA" ]] && [[ ! -z "$AUTOSWITCH_DEACTIVATED_CONDA_ENV" ]]; then
             _autoswitch_message "Switching Conda env: ${BOLD}${GREEN}%s${NORMAL}\n" "$AUTOSWITCH_DEACTIVATED_CONDA_ENV"
             conda activate $AUTOSWITCH_DEACTIVATED_CONDA_ENV
             unset AUTOSWITCH_DEACTIVATED_CONDA_ENV

--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -95,6 +95,12 @@ function _maybeworkon() {
             return
         fi
 
+        if [[ ! -z "$CONDA_DEFAULT_ENV" ]]; then
+            _autoswitch_message "Deactivating Conda env: ${BOLD}${GREEN}%s${NORMAL}\n" "$CONDA_DEFAULT_ENV"
+            export AUTOSWITCH_DEACTIVATED_CONDA_ENV=$CONDA_DEFAULT_ENV
+            conda deactivate
+        fi
+
         local py_version="$(_python_version "$venv_dir/bin/python")"
         local message="${AUTOSWITCH_MESSAGE_FORMAT:-"$DEFAULT_MESSAGE_FORMAT"}"
         message="${message//\%venv_type/$venv_type}"
@@ -106,11 +112,6 @@ function _maybeworkon() {
         # to prevent users seeing " Pipenv found itself running within a virtual environment" warning
         if [[ "$venv_type" == "pipenv" && "$PIPENV_VERBOSITY" != -1 ]]; then
             export PIPENV_VERBOSITY=-1
-        fi
-
-        if [[ ! -z "$CONDA_DEFAULT_ENV" ]]; then
-            export AUTOSWITCH_DEACTIVATED_CONDA_ENV=$CONDA_DEFAULT_ENV
-            conda deactivate
         fi
 
         # Much faster to source the activate file directly rather than use the `workon` command
@@ -236,8 +237,9 @@ function _default_venv()
         local venv_name="$(_get_venv_name "$VIRTUAL_ENV" "$venv_type")"
         _autoswitch_message "Deactivating: ${BOLD}${PURPLE}%s${NORMAL}\n" "$venv_name"
         deactivate
-        
+
         if [[ ! -z "$AUTOSWITCH_DEACTIVATED_CONDA_ENV" ]]; then
+            _autoswitch_message "Switching Conda env: ${BOLD}${GREEN}%s${NORMAL}\n" "$AUTOSWITCH_DEACTIVATED_CONDA_ENV"
             conda activate $AUTOSWITCH_DEACTIVATED_CONDA_ENV
             unset AUTOSWITCH_DEACTIVATED_CONDA_ENV
         fi


### PR DESCRIPTION
Set the environment variable `AUTOSWITCH_DEACTIVATE_CONDA` to make sure a Conda environment and a virtualenv are not both active at the same time.

No unit tests was added for the new setting, because I'm unsure how to write it, so it does not fail on systems without Anaconda or Miniconda. Should I add one executed conditionally, only when `conda` command is available?