### PR TITLE
Initiate migration of license GPLv3 -> MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,9 @@
+LICENSE TRANSITION
+
+Contributors agree to have their commits after November 2nd, 2022 licensed under MIT.
+To follow progress of the transition from GPL to MIT, see:
+https://github.com/MichaelAquilina/zsh-autoswitch-virtualenv/issues/185.
+
 GNU GENERAL PUBLIC LICENSE
 
 Version 3, 29 June 2007

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016- Michael Aquilina
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
re: #185

Migrating to MIT requires [earlier committers](https://github.com/MichaelAquilina/zsh-autoswitch-virtualenv/graphs/contributors) contributing under GPL agreeing to have their commits licensed MIT. 

While agreement from older contributors is sought, future commits will be licensed under MIT (which is forward compatible to GPL)