### PR TITLE
Allow specifying full path to virtual environment in .venv file

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -23,9 +23,13 @@ function _validated_source() {
 
 function _virtual_env_dir() {
     local venv_name="$1"
-    local VIRTUAL_ENV_DIR="${AUTOSWITCH_VIRTUAL_ENV_DIR:-$HOME/.virtualenvs}"
-    mkdir -p "$VIRTUAL_ENV_DIR"
-    printf "%s/%s" "$VIRTUAL_ENV_DIR" "$venv_name"
+    if [[ "$venv_name" = /* ]]; then
+        printf "$venv_name"
+    else
+        local VIRTUAL_ENV_DIR="${AUTOSWITCH_VIRTUAL_ENV_DIR:-$HOME/.virtualenvs}"
+        mkdir -p "$VIRTUAL_ENV_DIR"
+        printf "%s/%s" "$VIRTUAL_ENV_DIR" "$venv_name"
+    fi
 }
 
 


### PR DESCRIPTION
Hi,

Sometimes its useful for me to use an existing virtual environment so I added an option to specify an absolute path in a `.venv` file which then will be treated as a path to virtual environment.

For now this simply checks if the string in `.venv` file starts with `/` which works for me at the moment.

Let me know if this is a feature you would like to see added to the project. I am willing to do some extra work on this if anything else is needed before merging. 