### PR TITLE
Added export for environment variable.

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -7,7 +7,7 @@ AUTOSWITCH_PURPLE="\e[35m"
 AUTOSWITCH_BOLD="\e[1m"
 AUTOSWITCH_NORMAL="\e[0m"
 
-VIRTUAL_ENV_DIR="${AUTOSWITCH_VIRTUAL_ENV_DIR:-$HOME/.virtualenvs}"
+export VIRTUAL_ENV_DIR="${AUTOSWITCH_VIRTUAL_ENV_DIR:-$HOME/.virtualenvs}"
 
 function _validated_source() {
     local target_path="$1"


### PR DESCRIPTION
FIX: This line was not updating the environment variable due to the removal of the `export` command. When this was moved outside of the original function it was in `export` was removed and the `AUTOSWITCH_VIRTUAL_ENV_DIR` assignment stopped working.