### PR TITLE
Add support to detect uv based projects

### DIFF
--- a/tests/test_get_venv_type.zunit
+++ b/tests/test_get_venv_type.zunit
@@ -27,6 +27,33 @@
     assert "$output" same_as "poetry"
 }
 
+@test '_get_venv_type uv not found' {
+    touch "$TARGET/pyproject.toml"
+
+    run _get_venv_type "$TARGET"
+
+    assert $state equals 0
+    assert "$output" same_as "virtualenv"
+}
+
+@test '_get_venv_type uv found from pyproject.toml' {
+    echo "[uv.tool]" > "$TARGET/pyproject.toml"
+
+    run _get_venv_type "$TARGET"
+
+    assert $state equals 0
+    assert "$output" same_as "uv"
+}
+
+@test '_get_venv_type uv found from uv.lock' {
+    touch "$TARGET/uv.lock"
+
+    run _get_venv_type "$TARGET"
+
+    assert $state equals 0
+    assert "$output" same_as "uv"
+}
+
 @test '_get_venv_type virtualenv (requirements.txt)' {
     touch "$TARGET/requirements.txt"
 

--- a/tests/test_mkvenv.zunit
+++ b/tests/test_mkvenv.zunit
@@ -26,6 +26,14 @@
     function _activate_pipenv {
         echo "activating pipenv"
     }
+
+    function uv {
+        echo "uv" $@
+    }
+
+    function _activate_uv {
+        echo "activating uv"
+    }
 }
 
 @teardown {
@@ -79,6 +87,18 @@
     assert $status equals 0
     assert "$lines[1]" same_as "pipenv install --dev"
     assert "$lines[2]" same_as "activating pipenv"
+}
+
+@test 'mkvenv - (uv project) runs correct command' {
+    mkdir myproject
+    cd myproject
+    touch "uv.lock"
+
+    run mkvenv
+
+    assert $status equals 0
+    assert "$lines[1]" same_as "uv sync"
+    assert "$lines[2]" same_as "activating uv"
 }
 
 @test 'mkvenv - uses default python if set and not specified' {
@@ -186,6 +206,28 @@
     assert "$lines[2]" is_empty
     assert "$lines[3]" contains "If this is already installed but you are still seeing this message,"
     assert "$lines[4]" contains "then make sure the \e[1mpipenv\e[0m command is in your PATH.\n"
+    assert "$lines[5]" is_empty
+    assert ${#lines} equals 4
+}
+
+@test 'prints help message and disables plugin if uv not setup' {
+    touch "uv.lock"
+
+    # Mock type to fail
+    function type() {
+        if [[ "$1" == "uv" ]]; then
+            return 1
+        fi
+        return 0
+    }
+
+    run mkvenv
+
+    assert $status equals 0
+    assert "$lines[1]" contains "zsh-autoswitch-virtualenv requires 'uv' to install this project!"
+    assert "$lines[2]" is_empty
+    assert "$lines[3]" contains "If this is already installed but you are still seeing this message,"
+    assert "$lines[4]" contains "then make sure the \e[1muv\e[0m command is in your PATH.\n"
     assert "$lines[5]" is_empty
     assert ${#lines} equals 4
 }


### PR DESCRIPTION
[uv](https://docs.astral.sh/uv/) seems to become the de-facto standard Python package and project manager.

This pull request provides support to detect uv-based projects, based on
- `uv.lock`
- or `pyproject.toml` containing a `[tool.uv]` section

and initializes the virtual env with the `uv.sync` command.

`uv sync` standard behavior beeing creating the virtual env in `$project_dir/.venv/`, the virtual env is then handled as a "virtualenv" virtual env type.

```shell
$ cd myproj
Python uv project detected. Run mkvenv to setup autoswitching
$ mkvenv
Creating virtual environment at: .venv
[...truncated...]
Switching virtualenv: .venv [Python 3.11.6]
```