### PR TITLE
stop "setopt nullglob" from leaking into user's shell

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -383,6 +383,7 @@ function install_requirements() {
         fi
     fi
 
+    setopt localoptions
     setopt nullglob
     local requirements
     for requirements in **/*requirements.txt


### PR DESCRIPTION
In the `install_requirements` function, we do a `setopt nullglob` and never attempt to set it back to how it was set previously, which means that the behavior of the user's shell as a whole can (and likely will, as this isn't the default) change globbing behavior without  the user's knowledge or consent.

Adding a `setopt localoptions` before changing any options will cause changed options to reset to their original values when the enclosing function exits, stopping this option change from leaking into the user's shell. See `LOCAL_OPTIONS` at https://zsh.sourceforge.io/Doc/Release/Options.html for more details