### PR TITLE
fix(virtualenv):  Improve PATH management during virtualenv activation

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -74,6 +74,18 @@ function _get_venv_name() {
     printf "%s" "$venv_name"
 }
 
+# Function to ensure virtualenv bin is at the start of PATH
+function _ensure_virtualenv_path() {
+    # Remove the current virtualenv from PATH if it exists
+    if [[ -n "$VIRTUAL_ENV" ]]; then
+        PATH=:$PATH:
+        PATH=${PATH//:$VIRTUAL_ENV\/bin:/:}
+        PATH=${PATH#:}
+        PATH=${PATH%:}
+    fi
+    # Add the new virtualenv to the start of PATH
+    PATH="$venv_dir/bin:$PATH"
+}
 
 function _maybeworkon() {
     local venv_dir="$1"
@@ -87,7 +99,7 @@ function _maybeworkon() {
     fi
 
     # Don't reactivate an already activated virtual environment
-    if [[ -z "$VIRTUAL_ENV" || "$venv_dir" != "$VIRTUAL_ENV" ]]; then
+    if [[ -z "$VIRTUAL_ENV" || "$venv_dir" != "$VIRTUAL_ENV" || "$PATH" != "$venv_dir/bin"* ]]; then
 
         if [[ ! -d "$venv_dir" ]]; then
             printf "Unable to find ${AUTOSWITCH_PURPLE}$venv_name${AUTOSWITCH_NORMAL} virtualenv\n"
@@ -112,6 +124,9 @@ function _maybeworkon() {
         local activate_script="$venv_dir/bin/activate"
 
         _validated_source "$activate_script"
+
+        # Ensure the virtualenv's bin directory is at the start of PATH
+        _ensure_virtualenv_path
     fi
 }
 


### PR DESCRIPTION
I tried rebasing my previous branch and it somehow closed pr: https://github.com/MichaelAquilina/zsh-autoswitch-virtualenv/pull/204

I've updated my branch but it still fixes the same thing:

```
This fix addresses an issue where virtual environments were not activating when opening a terminal directly in a project directory or restarting the shell e.g. exec zsh in the project directory.

for some reason when reloading the shell it would set the .venv bin below the regular python bin in $PATH. This added function will doublecheck if the .venv path is set on top when the shell reloads in the project directory containing the .venv
```