### PR TITLE
.venv directory not detected from v3.8.0

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -123,7 +123,7 @@ function _check_path()
 {
     local check_dir="$1"
 
-    if [[ -f "${check_dir}/${AUTOSWITCH_FILE}" ]]; then
+    if [[ -e "${check_dir}/${AUTOSWITCH_FILE}" ]]; then
         printf "${check_dir}/${AUTOSWITCH_FILE}"
         return
     elif [[ -f "${check_dir}/poetry.lock" ]]; then


### PR DESCRIPTION
This PR is related to the issue #218

Since `.venv` is a directory, the `-f` check fails. This is the commit which changed that part: [Add better support for uv projects](https://github.com/MichaelAquilina/zsh-autoswitch-virtualenv/commit/f1b1da38459edcdeb23f80acdfbfbd5c4932856c)

I may be using uv in an unconventional way—I typically just use `uv venv` to create the `.venv` folder rather than using uv project management features. If there's a better workflow that's compatible with v3.8.2, I'm happy to adjust my approach.