### PR TITLE
fix: prioritize local .venv directory over parent project markers

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -47,6 +47,11 @@ function _autoswitch_message() {
 }
 
 
+function _is_valid_virtualenv() {
+    [[ -d "$1" ]] && [[ -f "$1/bin/activate" ]]
+}
+
+
 function _get_venv_type() {
     local venv_dir="$1"
     local venv_type="${2:-virtualenv}"
@@ -124,6 +129,9 @@ function _check_path()
     local check_dir="$1"
 
     if [[ -f "${check_dir}/${AUTOSWITCH_FILE}" ]]; then
+        printf "${check_dir}/${AUTOSWITCH_FILE}"
+        return
+    elif _is_valid_virtualenv "${check_dir}/${AUTOSWITCH_FILE}"; then
         printf "${check_dir}/${AUTOSWITCH_FILE}"
         return
     elif [[ -f "${check_dir}/poetry.lock" ]]; then
@@ -218,8 +226,7 @@ function check_venv()
                 local switch_to="$(<"$venv_path")"
                 _maybeworkon "$(_virtual_env_dir "$switch_to")" "virtualenv"
                 return
-            # $venv_path actually is itself a virtualenv
-            elif [[ -d "$venv_path" ]] && [[ -f "$venv_path/bin/activate" ]]; then
+            elif _is_valid_virtualenv "$venv_path"; then
                 _maybeworkon "$venv_path" "virtualenv"
                 return
             fi

--- a/tests/test_check_path.zunit
+++ b/tests/test_check_path.zunit
@@ -53,3 +53,33 @@
     assert $state equals 0
     assert "$output" is_empty
 }
+
+@test '_check_path - finds .venv directory with bin/activate' {
+    mkdir -p "$TARGET/.venv/bin"
+    touch "$TARGET/.venv/bin/activate"
+
+    run _check_path "$TARGET"
+
+    assert $state equals 0
+    assert "$output" same_as "$TARGET/.venv"
+}
+
+@test '_check_path - ignores .venv directory without bin/activate' {
+    mkdir -p "$TARGET/.venv"
+
+    run _check_path "$TARGET"
+
+    assert $state equals 0
+    assert "$output" is_empty
+}
+
+@test '_check_path - finds local .venv directory instead of parent marker' {
+    touch "$TARGET/uv.lock"
+    mkdir -p "$TARGET/subdir/.venv/bin"
+    touch "$TARGET/subdir/.venv/bin/activate"
+
+    run _check_path "$TARGET/subdir"
+
+    assert $state equals 0
+    assert "$output" same_as "$TARGET/subdir/.venv"
+}

--- a/tests/test_is_valid_virtualenv.zunit
+++ b/tests/test_is_valid_virtualenv.zunit
@@ -1,0 +1,43 @@
+#!/usr/bin/env zunit
+
+
+@setup {
+    export DISABLE_AUTOSWITCH_VENV="1"
+    load "../autoswitch_virtualenv.plugin.zsh"
+    TARGET="$(mktemp -d)"
+}
+
+@teardown {
+    rm -rf "$TARGET"
+}
+
+@test '_is_valid_virtualenv - returns true for valid virtualenv' {
+    mkdir -p "$TARGET/.venv/bin"
+    touch "$TARGET/.venv/bin/activate"
+
+    run _is_valid_virtualenv "$TARGET/.venv"
+
+    assert $state equals 0
+}
+
+@test '_is_valid_virtualenv - returns false for directory without bin/activate' {
+    mkdir -p "$TARGET/.venv/bin"
+
+    run _is_valid_virtualenv "$TARGET/.venv"
+
+    assert $state equals 1
+}
+
+@test '_is_valid_virtualenv - returns false for non-existent path' {
+    run _is_valid_virtualenv "$TARGET/.venv"
+
+    assert $state equals 1
+}
+
+@test '_is_valid_virtualenv - returns false for file' {
+    touch "$TARGET/.venv"
+
+    run _is_valid_virtualenv "$TARGET/.venv"
+
+    assert $state equals 1
+}


### PR DESCRIPTION
Fixes #218

This is an extended fix that validates `.venv` is a proper virtualenv (has `bin/activate`) rather than simply reverting to `-e` check.

## Summary

- Fix `_check_path()` to detect local `.venv` directory before searching parent directories for project markers
- When a subdirectory has its own `.venv` virtualenv, it was being ignored in favor of `uv.lock`/`poetry.lock`/`Pipfile` found in parent directories
- Add `_is_valid_virtualenv()` helper to eliminate code duplication

## Problem

```
~/projects/
├── .venv/                  # venv for projects/
├── uv.lock                 # uv marker
└── infra/
    └── ansible/
        └── .venv/          # venv for ansible/ — IGNORED
```

Running `cd ~/projects/infra/ansible` activates `~/projects/.venv` instead of `~/projects/infra/ansible/.venv`.

## Root Cause

`_check_path()` only checked for `.venv` as a **file** (`-f`), not as a **directory** (`-d`). The directory check existed in `check_venv()` but ran too late — after `_check_path()` already found `uv.lock` in a parent directory.

## Why not just revert to `-e`?

The simple fix (`-e` instead of `-f`) would match any `.venv` path, including empty directories. This solution explicitly validates that `.venv` contains `bin/activate`, ensuring it's a proper virtualenv before activation.

## Test plan

- [x] Add tests for `_is_valid_virtualenv()` helper (4 tests)
- [x] Add tests for `.venv` directory detection in `_check_path()` (3 tests)
- [x] All existing tests pass